### PR TITLE
Bundler compatibility

### DIFF
--- a/lib/inline.rb
+++ b/lib/inline.rb
@@ -510,7 +510,7 @@ VALUE #{method}_equals(VALUE value) {
     # Loads the generated code back into ruby
 
     def load
-      require "#{so_name}" or raise LoadError, "require on #{so_name} failed"
+      Kernel.require "#{so_name}" or raise LoadError, "require on #{so_name} failed"
     end
 
     ##


### PR DESCRIPTION
To avoid:

```
/Users/trevor/.rvm/gems/ree-1.8.7-2011.03/gems/RubyInline-3.8.4/lib/inline.rb:513:in `load': require on /Users/trevor/.ruby_inline/Inline_ImageScience_cdab.bundle failed (LoadError)
    from /Users/trevor/.rvm/gems/ree-1.8.7-2011.03/gems/RubyInline-3.8.4/lib/inline.rb:828:in `inline'
    from /Users/trevor/.rvm/gems/ree-1.8.7-2011.03/gems/image_science-1.2.1/lib/image_science.rb:90
```

It shouldn't be necessary, but here we are.

See also: https://github.com/carlhuda/bundler/issues/431
And: https://github.com/seattlerb/rubyinline/pull/1
