### PR TITLE
Fixes for Windows

### DIFF
--- a/lib/inline.rb
+++ b/lib/inline.rb
@@ -293,11 +293,7 @@ module Inline
                 0
               end
 
-      if WINDOZE
-        file, line = caller[1].split(/:\d/)
-      else
-        file, line = caller[1].split(/:/)
-      end
+      file, line = /(.*?):(\d+)/.match(caller[1]).captures
 
       result = "# line #{line.to_i + delta} \"#{file}\"\n" + result unless
         $DEBUG and not $TESTING


### PR DESCRIPTION
Hi,

These patches fix RubyInline on Windows for both mingw and especially mswin (Visual Studio). Mostly it was a matter of fixing the build command. For Visual Studio the linker and compiler commands were jumbled up, so I've fixed those, and set the output file name appropriately. There are some other tweaks as well.

All tests pass for both mingw and mswin, though mingw requires the Devkit in your PATH first.
