### PR TITLE
Improve windows compatibility (MinGW)

### DIFF
--- a/lib/inline.rb
+++ b/lib/inline.rb
@@ -644,7 +644,7 @@ VALUE #{method}_equals(VALUE value) {
         " -link /OUT:\"#{self.so_name}\" /LIBPATH:\"#{RbConfig::CONFIG['libdir']}\" /DEFAULTLIB:\"#{RbConfig::CONFIG['LIBRUBY']}\" /INCREMENTAL:no /EXPORT:Init_#{module_name}"
       when /mingw32/ then
         c = RbConfig::CONFIG
-        " -Wl,--enable-auto-import -L#{c['libdir']} -l#{c['RUBY_SO_NAME']}"
+        " -Wl,--enable-auto-import -L#{c['libdir']} -l#{c['RUBY_SO_NAME']} -o #{so_name.inspect}"
       when /i386-cygwin/ then
         ' -L/usr/local/lib -lruby.dll'
       else


### PR DESCRIPTION
The following changes attempt to correct the problems mentioned in Issue #31 when used on Ruby compiled with GCC (MinGW)

After changes applied, all tests passed on both 1.8.7 and 1.9.3:

```
ruby 1.8.7 (2012-10-12 patchlevel 371) [i386-mingw32]

Finished tests in 2.534145s, 24.8605 tests/s, 39.4610 assertions/s.
63 tests, 100 assertions, 0 failures, 0 errors, 0 skips

ruby 1.9.3p286 (2012-10-12) [i386-mingw32]

Finished tests in 2.730156s, 23.0756 tests/s, 36.6279 assertions/s.
63 tests, 100 assertions, 0 failures, 0 errors, 0 skips
```

Lotta Love :heart: :heart: :heart: 
