### PR TITLE
Fix arch header directoy with Ruby >= 2.0

### DIFF
--- a/lib/inline.rb
+++ b/lib/inline.rb
@@ -566,7 +566,9 @@ VALUE #{method}_equals(VALUE value) {
           flags = @flags.join(' ')
           libs  = @libs.join(' ')
 
-          config_hdrdir = if RUBY_VERSION > '1.9' then
+          config_hdrdir = if RbConfig::CONFIG['rubyarchhdrdir'] then
+                            "-I #{RbConfig::CONFIG['rubyarchhdrdir']}"
+                          elsif RUBY_VERSION > '1.9' then
                             "-I #{File.join hdrdir, RbConfig::CONFIG['arch']}"
                           else
                             nil


### PR DESCRIPTION
On Debian, the arch specific headear files are available in:
  /usr/include/x86_64-linux-gnu/ruby-2.1.0
while the current code is looking for:
  /usr/include/ruby-2.1.0/x86_64-linux-gnu
This prevents the compiler to find ruby/config.h.

Since Ruby 2.0, RbConfig::CONFIG['rubyarchhdrdir'] contains the proper
arch header directory, so use it in priority when available.