### PR TITLE
Link to the ruby interpreter

### DIFF
--- a/lib/inline.rb
+++ b/lib/inline.rb
@@ -585,6 +585,7 @@ VALUE #{method}_equals(VALUE value) {
                   (RbConfig::CONFIG['CCDLFLAGS']        if sane),
                   RbConfig::CONFIG['CFLAGS'],
                   (RbConfig::CONFIG['LDFLAGS']          if sane),
+                  (RbConfig::CONFIG['LIBRUBYARG']       if sane),
                   '-I', hdrdir,
                   config_hdrdir,
                   '-I', RbConfig::CONFIG['includedir'],


### PR DESCRIPTION
Guarantees that the proper shared object of ruby is being linked against
however that version of ruby is installed.