### PR TITLE
Fix Tocttou race condition in File patch

### DIFF
--- a/lib/inline.rb
+++ b/lib/inline.rb
@@ -883,6 +883,8 @@ class File
     end
 
     return renamed
+  rescue SystemCallError
+    return false
   end
 end # class File
 


### PR DESCRIPTION
There is a time of check to time of use race condition, that triggers from time to time for us. This patch fixes it.
The problem is when test on line 876 passes and then the file gets removed from an outside source line 878 raises.
In that case the original file is gone and can no longer be used, so return false.