### PR TITLE
Fix build options to compile C++ code

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -63,7 +63,8 @@ See hoe for more details.
   class MyTest
     inline(:C) do |builder|
       builder.include '<iostream>'
-      builder.add_compile_flags '-x c++', '-lstdc++'
+      builder.add_compile_flags '-x c++'
+      builder.add_link_flags '-lstdc++'
       builder.c '
         void hello(int i) {
           while (i-- > 0) {


### PR DESCRIPTION
The original code in README.md raises an build error of "undefined symbol" like the following:
```sh
<internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:85:in `require': /home/xxxx/.ruby_inline/ruby-3.0.0/Inline_MyTest_5d41402abc4b2a76b9719d911017c592.so: undefined symbol: _ZSt4cout - /home/xxxx/.ruby_inline/ruby-3.0.0/Inline_MyTest_5d41402abc4b2a76b9719d911017c592.so (LoadError)
        from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /var/lib/gems/3.0.0/gems/RubyInline-3.14.1/lib/inline.rb:521:in `load'
        from /var/lib/gems/3.0.0/gems/RubyInline-3.14.1/lib/inline.rb:845:in `inline'
        from test.rb:3:in `<class:MyTest>'
        from test.rb:2:in `<main>'
```
The solution has been existed in [original example2.rb](https://github.com/seattlerb/rubyinline/blob/be72ab54ab3170b1c3dd3d41867ff60d1174682c/example2.rb#L16).