### PR TITLE
Fix windoze variable in build()

### DIFF
--- a/lib/inline.rb
+++ b/lib/inline.rb
@@ -575,7 +575,7 @@ VALUE #{method}_equals(VALUE value) {
                             nil
                           end
 
-          windoze = WINDOZE and RUBY_PLATFORM =~ /mswin/
+          windoze = (WINDOZE and RUBY_PLATFORM =~ /mswin/)
           sane = ! windoze
           cmd = [ RbConfig::CONFIG['LDSHARED'],
                   flags,


### PR DESCRIPTION
Since the coupling order of "and" is lower than "=", the parentheses are probably necessary in the original intent.
This fix resolves the build failure in Windows Ruby ucrt version (github actions default >= 3.1).